### PR TITLE
p9, proto: fix some unsafe `unsafe` usages

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -176,7 +176,7 @@ func (h *fsHandler) getQID(p string, attach Attachment) (QID, error) {
 		return QID{}, err
 	}
 
-	sum := sha256.Sum256(*(*[]byte)(unsafe.Pointer(&p)))
+	sum := sha256.Sum256(unsafe.Slice(unsafe.StringData(p), len(p)))
 	path := binary.LittleEndian.Uint64(sum[:])
 
 	return QID{

--- a/proto/encoding.go
+++ b/proto/encoding.go
@@ -168,7 +168,7 @@ func (d *decoder) decode(v reflect.Value) {
 		buf := make([]byte, int(length))
 		d.read(buf)
 
-		v.SetString(*(*string)(unsafe.Pointer(&buf)))
+		v.SetString(unsafe.String(unsafe.SliceData(buf), len(buf)))
 
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {

--- a/proto/encoding.go
+++ b/proto/encoding.go
@@ -149,7 +149,9 @@ func (d *decoder) decode(v reflect.Value) {
 		case reflect.Uint8:
 			d.read(&length)
 		default:
-			d.read((*uint16)(unsafe.Pointer(&length)))
+			var t uint16
+			d.read(&t)
+			length = uint32(t)
 		}
 
 		if int(length) > v.Cap() {

--- a/stat.go
+++ b/stat.go
@@ -149,7 +149,7 @@ func (m FileMode) String() string {
 		}
 	}
 
-	return *(*string)(unsafe.Pointer(&buf))
+	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }
 
 // Stat is a stat value.


### PR DESCRIPTION
Ironic.

Fixes #75.