### PR TITLE
server: add `continue` after message read error

### DIFF
--- a/proto/server.go
+++ b/proto/server.go
@@ -74,6 +74,7 @@ func handleMessages(c net.Conn, p Proto, handler MessageHandler) {
 			}
 
 			log.Printf("Error reading message: %v", err)
+			continue
 		}
 
 		mode(func() {


### PR DESCRIPTION
After logging a read error, the function continues to process a potentially invalid message. This commit adds a continue statement to skip the rest of the execution.