### PR TITLE
addr: add Windows specific NamespaceDir() function

### DIFF
--- a/addr_other.go
+++ b/addr_other.go
@@ -1,5 +1,5 @@
-//go:build !linux && !darwin
-// +build !linux,!darwin
+//go:build !linux && !darwin && !windows
+// +build !linux,!darwin,!windows
 
 package p9
 

--- a/addr_windows.go
+++ b/addr_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+// +build windows
+
+package p9
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// NamespaceDir returns the path of the directory that is used for the
+// current namespace. On Windows, domain name is included, if available.
+//
+// If looking up the current user's name fails, this function will
+// panic.
+func NamespaceDir() string {
+	u, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	// On Windows, u.Username may contain the domain name as well (DOMAIN\user)
+	domain, user, found := strings.Cut(u.Username, "\\")
+	namespace := domain // will be the username if domain is not present
+	if found {
+		namespace = user + "." + domain
+	}
+
+	return filepath.Join(os.TempDir(), "ns."+namespace)
+}


### PR DESCRIPTION
This adds a Windows-specific NamespaceDir() function for better compatibility. The function accounts for the domain name that may be included in the username.