### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/cmd/p9/export.go
+++ b/cmd/p9/export.go
@@ -54,7 +54,12 @@ func (cmd *exportCmd) Run(options GlobalOptions, args []string) error {
 	if err != nil {
 		return util.Errorf("listen: %w", err)
 	}
-	defer lis.Close()
+	defer func() {
+		err := lis.Close()
+		if err != nil {
+			_, _ = fmt.Fprintf(fset.Output(), "Error closing listener: %v", err)
+		}
+	}()
 
 	errC := make(chan error, 1)
 	go func() {

--- a/cmd/p9/read.go
+++ b/cmd/p9/read.go
@@ -48,7 +48,12 @@ func (cmd *readCmd) Run(options GlobalOptions, args []string) error {
 	}
 
 	writeFile := func(arg string, f *p9.Remote) error {
-		defer f.Close()
+		defer func() {
+			err := f.Close()
+			if err != nil {
+				_, _ = fmt.Fprintf(fset.Output(), "Error closing remote: %v", err)
+			}
+		}()
 
 		_, err = io.Copy(os.Stdout, f)
 		if err != nil {
@@ -60,10 +65,20 @@ func (cmd *readCmd) Run(options GlobalOptions, args []string) error {
 
 	if cmd.tar {
 		out := tar.NewWriter(os.Stdout)
-		defer out.Close()
+		defer func() {
+			err := out.Close()
+			if err != nil {
+				_, _ = fmt.Fprintf(fset.Output(), "Error closing tar writer: %v", err)
+			}
+		}()
 
 		writeFile = func(arg string, f *p9.Remote) error {
-			defer f.Close()
+			defer func() {
+				err := f.Close()
+				if err != nil {
+					_, _ = fmt.Fprintf(fset.Output(), "Error closing remote: %v", err)
+				}
+			}()
 
 			fi, err := f.Stat("")
 			if err != nil {

--- a/cmd/p9/stat.go
+++ b/cmd/p9/stat.go
@@ -100,7 +100,9 @@ func (cmd *statCmd) printText(fi p9.DirEntry) {
 		' ',
 		0,
 	)
-	defer w.Flush()
+	defer func() {
+		_ = w.Flush()
+	}()
 
 	const timeFormat = "03:04 PM, January 2, 2006"
 

--- a/cmd/p9/write.go
+++ b/cmd/p9/write.go
@@ -68,7 +68,12 @@ func (cmd *writeCmd) Run(options GlobalOptions, args []string) error {
 		if err != nil {
 			return util.Errorf("open %q: %v", args[0], err)
 		}
-		defer f.Close()
+		defer func() {
+			err := f.Close()
+			if err != nil {
+				_, _ = fmt.Fprintf(fset.Output(), "Error closing remote %q: %v\n", args[0], err)
+			}
+		}()
 
 		if *app {
 			_, err := f.Seek(0, io.SeekEnd)

--- a/fs.go
+++ b/fs.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"sync"
 	"time"
@@ -720,7 +721,11 @@ func (h *fsHandler) Close() error {
 	h.fids.Range(func(k, v any) bool {
 		file := v.(*fsFile)
 		if file.file != nil {
-			file.file.Close()
+			err := file.file.Close()
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
+				return false
+			}
 		}
 		return true
 	})

--- a/proto/server.go
+++ b/proto/server.go
@@ -22,7 +22,12 @@ func Serve(lis net.Listener, p Proto, connHandler ConnHandler) (err error) {
 		}
 
 		go func() {
-			defer c.Close()
+			defer func(c net.Conn) {
+				err := c.Close()
+				if err != nil {
+					log.Printf("Error closing connection: %v", err)
+				}
+			}(c)
 
 			if h, ok := connHandler.(handleConn); ok {
 				h.HandleConn(c)
@@ -33,7 +38,12 @@ func Serve(lis net.Listener, p Proto, connHandler ConnHandler) (err error) {
 
 			mh := connHandler.MessageHandler()
 			if c, ok := mh.(io.Closer); ok {
-				defer c.Close()
+				defer func(c io.Closer) {
+					err := c.Close()
+					if err != nil {
+						log.Printf("Error closing connection: %v", err)
+					}
+				}(c)
 			}
 
 			handleMessages(c, p, mh)

--- a/remote.go
+++ b/remote.go
@@ -3,7 +3,9 @@ package p9
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -313,7 +315,12 @@ func (file *Remote) Stat(p string) (DirEntry, error) {
 		if err != nil {
 			return DirEntry{}, err
 		}
-		defer file.Close()
+		defer func() {
+			err := file.Close()
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error closing file %q: %v", p, err)
+			}
+		}()
 
 		return file.Stat("")
 	}

--- a/stat.go
+++ b/stat.go
@@ -318,7 +318,7 @@ type StatChanges struct {
 }
 
 func (c StatChanges) Mode() (FileMode, bool) {
-	return c.DirEntry.FileMode, c.DirEntry.FileMode != 0xFFFFFFFF
+	return c.FileMode, c.FileMode != 0xFFFFFFFF
 }
 
 func (c StatChanges) ATime() (time.Time, bool) {
@@ -334,7 +334,7 @@ func (c StatChanges) Length() (uint64, bool) {
 }
 
 func (c StatChanges) Name() (string, bool) {
-	return c.DirEntry.EntryName, c.DirEntry.EntryName != ""
+	return c.EntryName, c.EntryName != ""
 }
 
 func (c StatChanges) UID() (string, bool) {


### PR DESCRIPTION
Fixes `golangci-lint` issues; they're mostly about checking `Fprintf` for errors and handling errors in deferred functions.